### PR TITLE
Pachyderm update

### DIFF
--- a/.neuro/live.yml
+++ b/.neuro/live.yml
@@ -10,7 +10,7 @@ defaults:
     PACHY_URI: pachd.pachyderm.svc.cluster.local:30650
     PACHY_REPO: dogs-demo
     PROJECT_GIT_REPO: git@github.com:neuro-inc/mlops-demo-oss-dogs.git
-    PROJECT_GIT_BRANCH: master
+    PROJECT_GIT_BRANCH: ys/pachyderm_update
 
 volumes:
   remote_dataset:
@@ -48,9 +48,9 @@ images:
 
 jobs:
   create_pipeline:
-    preset: cpu-medium-p
-    pass_config: True
+    name: $[[ flow.title ]]-create-pipeline
     image: $[[ images.train.ref ]]
+    pass_config: True
     volumes:
       - secret:gh-rsa:/root/.ssh/id-rsa
     params:
@@ -95,8 +95,10 @@ jobs:
       # Create pipeline
       pachctl list pipeline train >/dev/null && pachctl delete pipeline train >/dev/null
       pachctl create pipeline -f /tmp/pipeline.json
+      echo "Pipeline created successfully."
 
   prepare_remote_dataset:
+    name: $[[ flow.title ]]-prepare-dataset
     image: neuromation/neuro-extras:20.12.15
     detach: False
     volumes:
@@ -114,6 +116,7 @@ jobs:
       fi
 
   extend_data:
+    name: $[[ flow.title ]]-extend-data
     image: $[[ images.train.ref ]]
     detach: False
     volumes:
@@ -147,15 +150,8 @@ jobs:
         --full_dataset ${{ volumes.remote_dataset.mount }}/images/Images/ \
         --nmber_of_imgs ${{ params.extend_dataset_by }} --skip_annotation_update
 
-      # Push dataset:
-      # Workaround for https://github.com/pachyderm/pachyderm/issues/4573 :
-      # put each file separately, not the whole directory:
-      pachctl start commit ${PACHY_REPO}@master
-      for img in `ls ${DATA_PATH}`; do
-        echo "Saving to pachyderm: ${DATA_PATH}/$img"
-        pachctl put file ${PACHY_REPO}@master:data/Images/$img --overwrite -f ${DATA_PATH}/$img | tee
-      done
-      pachctl finish commit ${PACHY_REPO}@master -m "Add `ls ${DATA_PATH} | wc -l` images"
+      # Push dataset
+      pachctl put file -o -r ${PACHY_REPO}@master:data/Images/ -f ${DATA_PATH}/ | tee
 
       # Validate dataset:
       pachctl list commit ${PACHY_REPO}@master
@@ -207,20 +203,11 @@ jobs:
         --ls_project_root ${LABEL_STUDIO_PROJECT} -- \
         start --use-gevent --no-browser ${LABEL_STUDIO_PROJECT} 
 
-      # Push labeling completions, dataset and annotation results to Pachyderm
-      # Workaround for https://github.com/pachyderm/pachyderm/issues/4573
-      # put each file separately, not the whole directory:
+      # Push labeling completions (label studio-specific files), images and annotation results
       pachctl start commit ${PACHY_REPO}@master
-      echo "Saving completions to pachyderm"
-      for compl in `ls ${COMPLETIONS}`; do
-        pachctl put file ${PACHY_REPO}@master:/ls-completions/$compl -o -f ${COMPLETIONS}/$compl | tee
-      done
-
-      for img in `ls ${DATA_PATH}`; do
-        echo "Saving to pachyderm: ${DATA_PATH}/$img"
-        pachctl put file ${PACHY_REPO}@master:data/Images/$img --overwrite -f ${DATA_PATH}/$img | tee
-      done
-      pachctl put file ${PACHY_REPO}@master:data/result.json --overwrite -f ${PROJECT}/data/result.json | tee
+      pachctl put file -o -r ${PACHY_REPO}@master:/ls-completions/ -f ${COMPLETIONS} | tee
+      pachctl put file -o -r ${PACHY_REPO}@master:data/Images/ -f ${DATA_PATH} | tee
+      pachctl put file -o    ${PACHY_REPO}@master:data/result.json -f ${PROJECT}/data/result.json | tee
       pachctl finish commit ${PACHY_REPO}@master -m "Commit annotations for `ls ${COMPLETIONS} | wc -l` images"
 
       # Validate dataset:

--- a/.neuro/live.yml
+++ b/.neuro/live.yml
@@ -58,6 +58,9 @@ jobs:
         descr: Storage path, where MLFlow server stores trained model binaries
       mlflow_uri:
         descr: MLFlow server URI
+      pachy_pipeline_name:
+        default: train
+        descr: MLFlow server URI
     env:
       EXPOSE_SSH: "yes"
       PYTHONPATH: /usr/project
@@ -66,6 +69,7 @@ jobs:
       MLFLOW_URI: ${{ params.mlflow_uri }}
       NEURO_TOKEN: secret:platform-token
       TRAIN_IMAGE_REF: ${{ images.train.ref }}
+      PACHY_PIPELINE_NAME: ${{ params.pachy_pipeline_name }}
     bash: |
       echo "IdentityFile ~/.ssh/id-rsa" > ~/.ssh/config
       ssh-keyscan github.com 2>/dev/null >> ~/.ssh/known_hosts
@@ -84,18 +88,18 @@ jobs:
 
       # Create a copy of pipeline template
       cp $${PROJECT}/config/pipeline.json /tmp/pipeline.json
-      # Store platform token
-      sed -i -e s/##NEURO_TOKEN##/${NEURO_TOKEN}/ /tmp/pipeline.json
-      # and cluster name
+      # Store platform token and cluster name
       NEURO_CLUSTER=$(neuro config show | grep "Current Cluster" | awk '{print $3}')
-      sed -i -e s/##NEURO_CLUSTER##/${NEURO_CLUSTER}/ /tmp/pipeline.json
-      # Probagate batch definition and parameters into the Pachyderm pypeline definition
+      sed -i -e s/##NEURO_TOKEN##/${NEURO_TOKEN}/ -e s/##NEURO_CLUSTER##/${NEURO_CLUSTER}/ /tmp/pipeline.json
+      # Probagate batch definition and its parameters into the Pachyderm pypeline definition
       sed -i -e s/##BATCH_B64##/${BATCH_B64}/ -e s/##PARAMS_B64##/${PARAMS_B64}/ /tmp/pipeline.json
+      # Set the pipeline name
+      sed -i -e s/##PIPELINE_NAME##/${PACHY_PIPELINE_NAME}/ /tmp/pipeline.json
 
       # Create pipeline
       pachctl list pipeline train >/dev/null && pachctl delete pipeline train >/dev/null
       pachctl create pipeline -f /tmp/pipeline.json
-      echo "Pipeline created successfully."
+      echo "Pipeline '${PACHY_PIPELINE_NAME}' created successfully."
 
   prepare_remote_dataset:
     name: $[[ flow.title ]]-prepare-dataset

--- a/.neuro/live.yml
+++ b/.neuro/live.yml
@@ -7,7 +7,7 @@ defaults:
   life_span: 1d
   env:
     # Those env vars will be assigned to every job in this flow
-    PACHY_URI: pachd.pachyderm.svc.cluster.local:650
+    PACHY_URI: pachd.pachyderm.svc.cluster.local:30650
     PACHY_REPO: dogs-demo
     PROJECT_GIT_REPO: git@github.com:neuro-inc/mlops-demo-oss-dogs.git
     PROJECT_GIT_BRANCH: master
@@ -48,9 +48,8 @@ images:
 
 jobs:
   create_pipeline:
-    preset: cpu-small
+    preset: cpu-medium-p
     pass_config: True
-    detach: True
     image: $[[ images.train.ref ]]
     volumes:
       - secret:gh-rsa:/root/.ssh/id-rsa
@@ -65,6 +64,8 @@ jobs:
       PROJECT: /usr/project
       MLFLOW_STORAGE: ${{ params.mlflow_storage }}
       MLFLOW_URI: ${{ params.mlflow_uri }}
+      NEURO_TOKEN: secret:platform-token
+      TRAIN_IMAGE_REF: ${{ images.train.ref }}
     bash: |
       echo "IdentityFile ~/.ssh/id-rsa" > ~/.ssh/config
       ssh-keyscan github.com 2>/dev/null >> ~/.ssh/known_hosts
@@ -78,21 +79,22 @@ jobs:
       # Store Neuro-flow batch definition base-64 encoded
       BATCH_B64=$(cat ${PROJECT}/.neuro/training.yaml | base64 -w 0)
 
-      # Substitue Neuro-flow batch parameters from job ENV vars (!) and store them b64 encoded
+      # Substitue Neuro-flow batch parameters from job ENV vars and store them b64 encoded
       PARAMS_B64=$(cat ${PROJECT}/.neuro/training-batch-params.yaml | envsubst | base64 -w 0)
 
       # Create a copy of pipeline template
       cp $${PROJECT}/config/pipeline.json /tmp/pipeline.json
-      # Add neuro config token
-      sed -i -e s/##NEURO_PASSED_CONFIG##/${NEURO_PASSED_CONFIG}/ /tmp/pipeline.json
+      # Store platform token
+      sed -i -e s/##NEURO_TOKEN##/${NEURO_TOKEN}/ /tmp/pipeline.json
+      # and cluster name
+      NEURO_CLUSTER=$(neuro config show | grep "Current Cluster" | awk '{print $3}')
+      sed -i -e s/##NEURO_CLUSTER##/${NEURO_CLUSTER}/ /tmp/pipeline.json
       # Probagate batch definition and parameters into the Pachyderm pypeline definition
       sed -i -e s/##BATCH_B64##/${BATCH_B64}/ -e s/##PARAMS_B64##/${PARAMS_B64}/ /tmp/pipeline.json
 
       # Create pipeline
       pachctl list pipeline train >/dev/null && pachctl delete pipeline train >/dev/null
       pachctl create pipeline -f /tmp/pipeline.json
-      # to keep the token alive, will be fixed soon
-      sleep infinity
 
   prepare_remote_dataset:
     image: neuromation/neuro-extras:20.12.15

--- a/.neuro/live.yml
+++ b/.neuro/live.yml
@@ -10,7 +10,7 @@ defaults:
     PACHY_URI: pachd.pachyderm.svc.cluster.local:30650
     PACHY_REPO: dogs-demo
     PROJECT_GIT_REPO: git@github.com:neuro-inc/mlops-demo-oss-dogs.git
-    PROJECT_GIT_BRANCH: ys/pachyderm_update
+    PROJECT_GIT_BRANCH: master
 
 volumes:
   remote_dataset:

--- a/.neuro/training-batch-params.yaml
+++ b/.neuro/training-batch-params.yaml
@@ -1,3 +1,4 @@
+train_image_ref: $TRAIN_IMAGE_REF
 mlflow_storage: $MLFLOW_STORAGE
 mlflow_uri: $MLFLOW_URI
 pachy_uri: $PACHY_URI

--- a/.neuro/training.yaml
+++ b/.neuro/training.yaml
@@ -7,21 +7,16 @@ defaults:
     strategy: none
 
 params:
+  train_image_ref: ~
   mlflow_storage: ~
   mlflow_uri: ~
   pachy_uri: ~
   project_git_repo: ~
   project_git_branch: ~
 
-images:
-  train:
-    ref: image:$[[ flow.flow_id ]]/train:21.5.13-pachyderm
-  seldon:
-    ref: image:$[[ flow.flow_id ]]/seldon:20.12.16
-
 tasks:
   - id: train
-    image: $[[ images.train.ref ]]
+    image: $[[ params.train_image_ref ]]
     preset: cpu-medium-p
     life_span: 10d
     volumes:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Create a secret with a private SSH key for GitHub repository access (pull/push a
 neuro secret add gh-rsa @~/.ssh/id_rsa
 ```
 
+Create a secret with your account token for training pipeline authentication
+
+```shell
+neuro secret add platform-token $(neuro config show-token)
+```
+
 Set up the variables provided by Neu.ro team needed to run the loads in your cluster.
 
 ```shell

--- a/config/pipeline.json
+++ b/config/pipeline.json
@@ -1,6 +1,6 @@
 {
   "pipeline": {
-    "name": "train"
+    "name": "##PIPELINE_NAME##"
   },
   "description": "Retrain the model after labeling data",
   "transform": {

--- a/config/pipeline.json
+++ b/config/pipeline.json
@@ -8,10 +8,11 @@
     "cmd": [
       "bash",
       "-c",
-      "cd /tmp; mkdir -p .neuro; echo $BATCH_B64 | base64 -d > .neuro/training.yaml; echo $PARAMS_B64 | base64 -d > .neuro/params.yaml; neuro-flow bake training --meta-from-file .neuro/params.yaml --local-executor"
+      "neuro config login-with-token ${NEURO_TOKEN}; neuro config switch-cluster ${NEURO_CLUSTER}; cd /tmp; mkdir -p .neuro; echo $BATCH_B64 | base64 -d > .neuro/training.yaml; echo $PARAMS_B64 | base64 -d > .neuro/params.yaml; neuro-flow bake training --meta-from-file .neuro/params.yaml --local-executor"
     ],
     "env": {
-      "NEURO_PASSED_CONFIG": "##NEURO_PASSED_CONFIG##",
+      "NEURO_TOKEN": "##NEURO_TOKEN##",
+      "NEURO_CLUSTER": "##NEURO_CLUSTER##",
       "BATCH_B64": "##BATCH_B64##",
       "PARAMS_B64": "##PARAMS_B64##"
     }


### PR DESCRIPTION
In this PR I've updated the following Pachyderm configuration:
1. Removed workarounds to keep pachd pods alive (with a previous version of pachyderm, pachd pods were constantly OOMKilled while pushing the entire directory instead of separate files). Bump to the new server version also required a port change.
2. Pass permanent neuro login token to Pachyderm pipeline. Previously we needed to keep alive the `create_pipeline` neuro Job, since the token, generated within the job, was bonded to the job `running` state.
